### PR TITLE
Replace fixture generation with factory_bot

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,11 @@ module TraineePlanner
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    config.generators do |g|
+      g.test_framework :rspec
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
+    end
+
     config.generators.after_generate do |files|
       parsable_files = files.filter { |file| file.end_with?('.rb') }
       system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)


### PR DESCRIPTION
## Task: 
Replace fixture generation with factory_bot
## Change proposed in this pull request:
Add factory_bot to fixture_replacement to config.generators in `application.rb`