### PR TITLE
Fix category scopes

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,7 +5,7 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: %i[update destroy]
 
   def index
-    @categories = current_user.categories.page(params[:page]).per(params[:per_page])
+    @categories = current_user.categories.ordered_by_creation_time.page(params[:page]).per(params[:per_page])
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -8,5 +8,5 @@ class Category < ApplicationRecord
   belongs_to :user
   has_many :events, dependent: :destroy
 
-  default_scope { order(:id) }
+  scope :ordered_by_creation_time, -> { order(:created_at) }
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe Category do
   end
 
   describe 'scopes' do
-    describe 'default_scope' do
-      subject(:default_scope) { described_class.all }
+    describe 'ordered_by_creation_time' do
+      subject(:ordered_scope) { described_class.ordered_by_creation_time }
 
       let!(:first_category) { create(:category) }
       let!(:last_category) { create(:category) }
 
       before { first_category.update(name: 'Updated') }
 
-      it { expect(default_scope).to eq([first_category, last_category]) }
+      it { expect(ordered_scope).to eq([first_category, last_category]) }
     end
   end
 end


### PR DESCRIPTION
## Task: 
Stop unexpected behavior when used sorting in associated models 
## Changes proposed in this pull request:
* Remove `default_scope` from category model
* Add `ordered_by_creation_time` scope to category model
* Update `CategoriesController` and model test for category
