### PR TITLE
Add gems for testing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,4 +118,6 @@ group :test do
   gem 'selenium-webdriver'
   # Keep your Selenium WebDrivers updated automatically [https://github.com/titusfortner/webdrivers]
   gem 'webdrivers', '~> 5.0', require: false
+  # Record your test suite's HTTP interactions and replay them during tests [https://github.com/vcr/vcr]
+  gem 'vcr'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -122,4 +122,6 @@ group :test do
   gem 'vcr'
   # Library for stubbing and setting expectations on HTTP requests in Ruby [https://github.com/bblimke/webmock]
   gem 'webmock'
+  # Providing time travel, freezing and acceleration capabilitie [https://github.com/travisjeffery/timecop]
+  gem 'timecop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -120,4 +120,6 @@ group :test do
   gem 'webdrivers', '~> 5.0', require: false
   # Record your test suite's HTTP interactions and replay them during tests [https://github.com/vcr/vcr]
   gem 'vcr'
+  # Library for stubbing and setting expectations on HTTP requests in Ruby [https://github.com/bblimke/webmock]
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    vcr (6.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -394,6 +395,7 @@ DEPENDENCIES
   time_difference
   turbo-rails
   tzinfo-data
+  vcr
   web-console
   webdrivers (~> 5.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,7 @@ GEM
     tilt (2.2.0)
     time_difference (0.5.0)
       activesupport
+    timecop (0.9.8)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -400,6 +401,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   time_difference
+  timecop
   turbo-rails
   tzinfo-data
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     database_cleaner-active_record (2.1.0)
       activerecord (>= 5.a)
@@ -130,6 +132,7 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -350,6 +353,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -398,6 +405,7 @@ DEPENDENCIES
   vcr
   web-console
   webdrivers (~> 5.0)
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/database_cleaner'
+require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -79,4 +80,10 @@ Shoulda::Matchers.configure do |config|
     with.test_framework :rspec
     with.library :rails
   end
+end
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/vcr_cassettes'
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.allow_http_connections_when_no_cassette = true
 end


### PR DESCRIPTION
## Task: 
Add gems that simplify api testing
## Changes proposed in this pull request:
* Add `timecop` gem
* Add `webmock` gem
* Add and configure `vcr` gem