### PR TITLE
Fix problem with js loading

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
     <%= javascript_importmap_tags %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, type: :module %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: :module %>
   </head>
 
   <body>


### PR DESCRIPTION
## Task:
Fix problems with js loading in firefox

## Change proposed in this pull request:
* Remove `defer: true` from `javascript_include_tag`