### PR TITLE
Remove mappings for dbs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ services:
      - ./.env
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    ports:
-      - 5433:5432
 
   redis:
     container_name: redis_db
@@ -43,8 +41,6 @@ services:
       - ./.env
     volumes:
       - redis-data:/var/lib/redis/data
-    ports:
-      - 6380:6379
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Task:
Remove mappings for `redis` and `postgresql` in docker-compose.yml